### PR TITLE
Discover inboxes of actors when doing inbox discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.46.tgz",
       "integrity": "sha512-rRkP4kb5JYIfAoRKaDbcdPZBcTNOgzSApyzhPN9e6rhViSJAWQGlSXIX5gc75iR02jikhpzy3usu31wMHllfFw=="
     },
+    "@types/node-fetch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.1.tgz",
+      "integrity": "sha512-IfDil0fSMq59n4UsIzgRd5gsgmgn9dl9PzZbguKPsGBpLEIFC7Fr4AroQjIeCYOcDsP1Lszm10wirpaEP26Lhg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.46"
+      }
+    },
     "@types/parse-link-header": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.0.tgz",
@@ -277,6 +286,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -369,6 +384,12 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1212,7 +1233,7 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
           "dev": true
         }
       }
@@ -2226,6 +2247,78 @@
       "requires": {
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
+      }
+    },
+    "tslib": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
+      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
+      "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.15.1",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.4.0",
+        "semver": "5.4.1",
+        "tslib": "1.9.2",
+        "tsutils": "2.27.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
+      "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.2"
       }
     },
     "tunnel-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     "@types/dompurify": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-0.0.31.tgz",
-      "integrity": "sha512-Vi2VBl262MjJuxpROjQU3AuBv1NgA7oaL9jqLJRgF60tps4GR/9qzXN0P4pRYPXsBA0b10AF1M6wO74uwGqtmw=="
+      "integrity": "sha1-8VLVqB8rViXinxHrAWzZswHQ1LQ="
     },
     "@types/express": {
       "version": "4.0.39",
@@ -44,12 +44,12 @@
     "@types/mime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
+      "integrity": "sha1-WnMG42fFObn2VDSZ3o3VGfrDeos="
     },
     "@types/morgan": {
       "version": "1.7.35",
       "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.7.35.tgz",
-      "integrity": "sha512-E9qFi0seOkdlQnCTPv54brNfGWeFdRaEhI5tSue4pdx/V+xfxvMETsxXhOEcj1cYL+0n/jcTEmj/jD2gjzCwMg==",
+      "integrity": "sha1-Y1j1ApMcwlg9epQkjEFRi6pohJQ=",
       "requires": {
         "@types/express": "4.0.39"
       }
@@ -62,7 +62,7 @@
     "@types/parse-link-header": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.0.tgz",
-      "integrity": "sha512-fCA3btjE7QFeRLfcD0Sjg+6/CnmC66HpMBoRfRzd2raTaWMJV21CCZ0LO8MOqf8onl5n0EPfjq4zDhbyX8SVwA=="
+      "integrity": "sha1-afBZ5AoPqT3C4JXUFCOVrmrcXXo="
     },
     "@types/serve-static": {
       "version": "1.13.1",
@@ -313,7 +313,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -411,6 +411,17 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
+      }
+    },
     "cryptiles": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
@@ -467,7 +478,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -522,6 +533,12 @@
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-0.8.9.tgz",
       "integrity": "sha1-/OwCH5F7UfQqeK9x14dae6UU/WQ="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -702,7 +719,7 @@
     "eslint-plugin-no-only-tests": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.0.0.tgz",
-      "integrity": "sha512-1huEDo1+Yu2thtdxxzkB0lfPlD1ltNqxyFAO4HfFjB5AVh7FCsAENtJtCjMXmUjyCKgeF1bTnDFJqpIWMkdZtA==",
+      "integrity": "sha1-x2wp6XO7dvJMFOIPqH8f8fDBjV8=",
       "dev": true
     },
     "eslint-plugin-promise": {
@@ -777,6 +794,21 @@
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.35"
+      }
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "exit-hook": {
@@ -857,6 +889,12 @@
         "mime-types": "2.1.17"
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -889,7 +927,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -903,7 +941,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -1144,6 +1182,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -1299,6 +1343,16 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
     "ltcdr": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
@@ -1309,6 +1363,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
       "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "marked": {
@@ -1332,7 +1392,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -1388,7 +1448,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -1541,6 +1601,15 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1603,6 +1672,21 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
@@ -1724,7 +1808,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -1753,12 +1837,27 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
@@ -1794,10 +1893,19 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
+      }
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
       }
     },
     "sprintf-js": {
@@ -1825,6 +1933,15 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -1922,7 +2039,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -2036,6 +2153,71 @@
         }
       }
     },
+    "tsc-watch": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-1.0.22.tgz",
+      "integrity": "sha512-PSs7XD5H6398Ra7dHjmw0fD7+BNKcPndRBbxqS8KcW7VBfWq9BPniCdyWLs1K+H1N9jfrWJFMOlMd5rfQzJEgw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "cross-spawn": "5.1.0",
+        "ps-tree": "1.1.0",
+        "strip-ansi": "4.0.0",
+        "typescript": "2.5.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "tsconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
@@ -2131,7 +2313,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60="
     },
     "whatwg-encoding": {
       "version": "1.0.1",
@@ -2155,6 +2337,15 @@
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         }
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
       }
     },
     "winston": {
@@ -2211,6 +2402,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-standard": "^2.0.1",
     "ts-node": "^3.3.0",
+    "tsc-watch": "^1.0.22",
     "typescript-eslint-parser": "^8.0.1"
   },
   "config": {
@@ -46,9 +47,10 @@
     "lint": "eslint --fix 'src/**/*.ts' 'test/**/*.ts' 'bin/**/*.ts'",
     "test": "ts-node --harmony test",
     "start": "node ./dist/bin/server",
-    "start-dev": "ts-node --harmony bin/server",
+    "start-dev": "tsc-watch --onSuccess 'npm start'",
     "tsc": "tsc",
-    "ts.build": "tsc && copyfiles './src/**/*.json' dist/"
+    "build": "tsc && npm run build.copyfiles",
+    "build.copyfiles": "copyfiles './src/**/*.json' dist/"
   },
   "author": "",
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.46",
+    "@types/node-fetch": "^2.1.1",
     "copyfiles": "^1.2.0",
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.2.0",
@@ -38,6 +39,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "ts-node": "^3.3.0",
     "tsc-watch": "^1.0.22",
+    "tslint": "^5.10.0",
     "typescript-eslint-parser": "^8.0.1"
   },
   "config": {

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -259,9 +259,9 @@ const deliverActivity = async function (activity: Activity, target: string, { de
         accept: `${ASJsonLdProfileContentType}, text/html`
       }
     }))
-  } catch (e) {
-    logger.error("Error delivering activity to target. This is normal if the target doesnt speak great ActivityPub.", e)
-    throw new deliveryErrors.TargetRequestFailed(e.message)
+  } catch (error) {
+    logger.error(`Error delivering activity to target=${target}. This is normal if the target doesnt speak great ActivityPub.`, error)
+    throw new deliveryErrors.TargetRequestFailed(error.message)
   }
   logger.debug(`res ${targetProfileResponse.statusCode} inbox discovery for ${target}`)
 
@@ -427,7 +427,7 @@ async function actorInboxesFromBody (body: string, contentType: string): Promise
       return []
     }
   }))
-  logger.warn("Actor URLs", actorUrls)
+  logger.debug("Actor URLs", actorUrls)
   const actorInboxes = flatten(await Promise.all(actorUrls.map(async actorUrl => {
     try {
       const res = await fetch(actorUrl, {

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -15,6 +15,7 @@ import {Activity, ASObject, Extendable, JSONLD, LDValue, isActivity} from './typ
 import { get } from 'lodash'
 
 import { createLogger } from '../src/logger'
+import fetch from 'node-fetch';
 const logger = createLogger('activitypub')
 
 exports.publicCollectionId = 'https://www.w3.org/ns/activitystreams#Public'
@@ -60,7 +61,7 @@ export const objectTargets = async (o:ASObject, recursionLimit: number, fetch : 
                 })
       ))
     : []
-  // debuglog('objectTargets', { audience, recursedAudience, recursionLimit, activity })
+  // logger.debug('objectTargets', { audience, recursedAudience, recursionLimit, activity })
   const targets = [...audience, ...recursedAudience]
   const deduped = Array.from(new Set(targets))
   return deduped
@@ -102,7 +103,7 @@ export const objectTargetsNoRecurse = async (
       }
     })))
     if (res.statusCode !== 200) {
-      console.warn('got non-200 response when fetching ${obj} as part of activityAudience()')
+      logger.warn('got non-200 response when fetching ${obj} as part of activityAudience()')
       return
     }
     const body = await readableToString(res)
@@ -113,11 +114,11 @@ export const objectTargetsNoRecurse = async (
         try {
           return JSON.parse(body)
         } catch (error) {
-          console.error("Couldn't parse fetched response body as JSON when determining activity audience", {body}, error)
+          logger.error("Couldn't parse fetched response body as JSON when determining activity audience", {body}, error)
           return
         }
       default:
-        console.warn(`Unexpected contentType=${resContentType} of response when fetching ${audienceUrl} to determine activityAudience`)
+        logger.warn(`Unexpected contentType=${resContentType} of response when fetching ${audienceUrl} to determine activityAudience`)
         return
     }
   }))).filter(Boolean)
@@ -204,13 +205,13 @@ const fetchProfile = exports.fetchProfile = async (target: string) => {
       accept: `${ASJsonLdProfileContentType},text/html`
     }
   }))
-  debuglog('fetchProfile ' + target)
+  logger.debug('fetchProfile ' + target)
   try {
     var targetProfileResponse = await sendRequest(targetProfileRequest)
   } catch (e) {
     throw new deliveryErrors.TargetRequestFailed(e.message)
   }
-  debuglog(`res ${targetProfileResponse.statusCode} fetchProfile for ${target}`)
+  logger.debug(`res ${targetProfileResponse.statusCode} fetchProfile for ${target}`)
 
   switch (targetProfileResponse.statusCode) {
     case 200:
@@ -251,7 +252,7 @@ async function outboxFromResponse (res: IncomingMessage) {
 // deliver an activity to a target
 const deliverActivity = async function (activity: Activity, target: string, { deliverToLocalhost } : { deliverToLocalhost: Boolean }) {
   // discover inbox
-  debuglog('req inbox discovery ' + target)
+  logger.debug('req inbox discovery ' + target)
   try {
     var targetProfileResponse = await followRedirects(Object.assign(url.parse(target), {
       headers: {
@@ -262,7 +263,7 @@ const deliverActivity = async function (activity: Activity, target: string, { de
     logger.error("Error delivering activity to target. This is normal if the target doesnt speak great ActivityPub.", e)
     throw new deliveryErrors.TargetRequestFailed(e.message)
   }
-  debuglog(`res ${targetProfileResponse.statusCode} inbox discovery for ${target}`)
+  logger.debug(`res ${targetProfileResponse.statusCode} inbox discovery for ${target}`)
 
   switch (targetProfileResponse.statusCode) {
     case 200:
@@ -272,90 +273,13 @@ const deliverActivity = async function (activity: Activity, target: string, { de
       throw new deliveryErrors.TargetRequestFailed(`Got unexpected status code ${targetProfileResponse.statusCode} when requesting ${target} to determine inbox URL`)
   }
 
-  debuglog(`deliverActivity to target ${target}`)
+  logger.debug(`deliverActivity to target ${target}`)
   const body = await readableToString(targetProfileResponse)
   const contentType = ensureArray(targetProfileResponse.headers['content-type']).map((contentTypeValue: string) => contentTypeValue.split(';')[0]).filter(Boolean)[0]  
   let inbox: string = inboxFromHeaders(targetProfileResponse) || await inboxFromBody(body, contentType)
-
-  function inboxFromHeaders (res: IncomingMessage) {
-    let inbox
-    // look in res Link header
-    const linkHeaders = ensureArray(res.headers.link)
-    const inboxLinks = linkHeaders
-      .map(parseLinkHeader)
-      .filter(Boolean)
-      .map((parsed: any) => {
-        return parsed['http://www.w3.org/ns/ldp#inbox']
-      })
-      .filter(Boolean)
-    let inboxLink
-    if (Array.isArray(inboxLinks)) {
-      if (inboxLinks.length > 1) {
-        console.warn('More than 1 LDN inbox found, but only using 1 for now', inboxLinks)
-        inboxLink = inboxLinks[0]
-      }
-    } else {
-      inboxLink = inboxLinks
-    }
-
-    if (inboxLink) {
-      inbox = url.resolve(target, inboxLink.url)
-    }
-    return inbox
+  if (inbox) {
+    inbox = url.resolve(target, inbox)
   }
-
-  async function inboxFromBody (body: string, contentType: string) {
-    let inboxes
-    debuglog(`inboxFromBody got response contentType=${contentType}`)
-    switch (contentType) {
-      case 'application/json':
-        try {
-          var targetProfile = JSON.parse(body)
-        } catch (e) {
-          throw new deliveryErrors.TargetParseFailed(e.message)
-        }
-        inboxes = ensureArray(targetProfile.inbox).map(inbox => url.resolve(target, inbox))
-        break
-      case 'text/html':
-        let ld: Extendable<JSONLD>[] = await rdfaToJsonLd(body)
-        let targetSubject = ld.find((x) => x['@id'] === 'http://localhost/')
-        if ( ! targetSubject) {
-          debuglog('no targetSubject so no ldb:inbox after checking text/html for ld. got ld', ld)
-          inboxes = []
-        } else {
-          inboxes = targetSubject['http://www.w3.org/ns/ldp#inbox'].map((i: JSONLD) => i['@id'])          
-        }
-        break;
-      case 'application/ld+json':
-        const obj = JSON.parse(body)
-        const compacted = await jsonld.compact(obj, {
-          '@context': [
-            'https://www.w3.org/ns/activitystreams',
-            {
-              'distbin:inbox': {
-                '@id': 'ldp:inbox',
-                '@container': '@set'
-              }
-            }
-          ]
-        })
-        const compactedInbox = (compacted['distbin:inbox'] || []).map((o: {id: string}) => typeof o === 'object' ? o.id : o)
-        inboxes = compactedInbox.length ? compactedInbox : ensureArray(obj.inbox)
-        break;
-      default:
-        throw new Error(`Don't know how to parse ${contentType} to determine inbox URL`)
-    }
-    if (!inboxes || !inboxes.length) {
-      debuglog(`Could not determine ActivityPub inbox from ${contentType} response`)
-      return
-    }
-    if (inboxes.length > 1) {
-      console.warn(`Using only first inbox, but there were ${inboxes.length}: ${inboxes}`)
-    }
-    const inbox: string = inboxes[0]
-    return inbox
-  }
-
   if (!inbox) throw new deliveryErrors.InboxDiscoveryFailed('No .inbox found for target ' + target)
 
   // post to inbox
@@ -381,7 +305,7 @@ const deliverActivity = async function (activity: Activity, target: string, { de
     throw new deliveryErrors.DeliveryRequestFailed(e.message)
   }
   const deliveryResponseBody = await readableToString(deliveryResponse)
-  debuglog(`ldn notify res ${deliveryResponse.statusCode} ${inbox} ${deliveryResponseBody.slice(0, 100)}`)
+  logger.debug(`ldn notify res ${deliveryResponse.statusCode} ${inbox} ${deliveryResponseBody.slice(0, 100)}`)
   if (deliveryResponse.statusCode >= 400 && deliveryResponse.statusCode <= 599) {
     // client or server error
     throw new deliveryErrors.DeliveryErrorResponse(`${deliveryResponse.statusCode} response from ${inbox}\nResponse Body:\n${deliveryResponseBody}`)
@@ -398,11 +322,11 @@ exports.targetAndDeliver = async function (activity: Activity,
   targets = targets ||  (await objectTargets(activity, 0))
     .map(t => {
       const url = getASId(t)
-      if ( ! url) debuglog('Cant determine URL to deliver to for target, so skipping', t)
+      if ( ! url) logger.debug('Cant determine URL to deliver to for target, so skipping', t)
       return url
     })
     .filter(Boolean)
-  debuglog('targetAndDeliver targets', targets)
+  logger.debug('targetAndDeliver targets', targets)
   let deliveries: string[] = []
   let failures: Error[] = []
   await Promise.all(
@@ -417,10 +341,174 @@ exports.targetAndDeliver = async function (activity: Activity,
           .catch(e => failures.push(e))
       })
   )
-  debuglog('finished targetAndDeliver', { failures, deliveries })
+  logger.debug('finished targetAndDeliver', { failures, deliveries })
   if (failures.length) {
-    debuglog('failures delivering ' + failures.map(e => e.stack))
+    logger.debug('failures delivering ' + failures.map(e => e.stack))
     throw new deliveryErrors.SomeDeliveriesFailed('SomeDeliveriesFailed', failures, deliveries)
   }
   return deliveries
+}
+
+export const inboxUrl = async (subjectUrl: string) => {
+  const subjectResponse = await fetch(subjectUrl)
+  const subject = await subjectResponse.json()
+  const inbox = subject.inbox
+  if ( ! inbox) return inbox
+  const inboxUrl = url.resolve(subjectUrl, inbox)
+  return inboxUrl
+}
+
+
+function inboxFromHeaders (res: IncomingMessage) {
+  let inbox
+  // look in res Link header
+  const linkHeaders = ensureArray(res.headers.link)
+  const inboxLinks = linkHeaders
+    .map(parseLinkHeader)
+    .filter(Boolean)
+    .map((parsed: any) => {
+      return parsed['http://www.w3.org/ns/ldp#inbox']
+    })
+    .filter(Boolean)
+  let inboxLink
+  if (Array.isArray(inboxLinks)) {
+    if (inboxLinks.length > 1) {
+      logger.warn('More than 1 LDN inbox found, but only using 1 for now', inboxLinks)
+      inboxLink = inboxLinks[0]
+    }
+  } else {
+    inboxLink = inboxLinks
+  }
+  return inbox
+}
+
+/**
+ * Determine the ActivityPub Inbox of a fetched resource
+ * @param body - The fetched resource
+ * @param contentType - HTTP Content Type header of fetched resource
+ * 
+ * This will look for the following kinds of inboxes, and return the first one it finds:
+ * * a 'direct' inbox
+ * * an actor, which is a separate resource, that has an inbox for activities related to objects that actor is related to
+ * 
+ * @TODO (bengo): Allow returning all inboxes we can find
+ */
+async function inboxFromBody (body: string, contentType: string) {
+  try {
+    const directInbox = await directInboxFromBody(body, contentType)
+    if (directInbox) return directInbox
+  } catch (error) {
+    logger.debug("Error looking for directInbox", error)
+  }
+  const actorInboxes = await actorInboxesFromBody(body, contentType);
+  if (actorInboxes.length > 1) {
+    logger.warn("Got more than one actorInboxes. Only using first.", actorInboxes)
+  }
+  if (actorInboxes.length) {
+    return actorInboxes[0]
+  }
+}
+
+
+
+/**
+ * Given a resource as a string, determine the inboxes for any actors of the resource
+ */
+async function actorInboxesFromBody (body: string, contentType: string): Promise<Array<string>> {
+  const bodyData = bodyToJsonLd(body, contentType)
+  const compacted = await jsonld.compact(bodyData, {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+  })
+  const actorUrls = flatten(ensureArray(bodyData.actor).filter(Boolean).map(actor => {
+    if (typeof actor === 'string') return [actor]
+    else if (actor.url) return ensureArray(actor.url)
+    else {
+      logger.debug("Could not determine url from actor", { actor })
+      return []
+    }
+  }))
+  const actorInboxes = flatten(await Promise.all(actorUrls.map(async actorUrl => {
+    try {
+      const res = await fetch(actorUrl);
+      const actor = await res.json();
+      return ensureArray(actor.inbox).map(inboxUrl => url.resolve(actorUrl, inboxUrl))
+    } catch (error) {
+      logger.warn("Error fetching actor to lookup inbox", error)
+    }
+  })))
+  return actorInboxes
+}
+
+const UnexpectedContentTypeError = makeErrorClass('UnexpectedContentTypeError')
+
+/**
+ * Given a resource as a string + contentType, return a representation of it's linked data as a JSON-LD Object
+ */
+function bodyToJsonLd (body: string, contentType: string) {
+  logger.debug('bodyToJsonLd', { contentType })
+  switch (contentType) {
+    case "application/json":
+    case 'application/ld+json':
+      const data = JSON.parse(body)
+      return data
+    default:
+      logger.warn("Unable due bodyToJsonLd due to unexpected contentType", { contentType })
+      throw new UnexpectedContentTypeError(`Dont know how to parse contentType=${contentType}`)
+  }
+}
+
+/**
+ * Given a resource as a string, return it's ActivityPub inbox URL (if any)
+ */
+async function directInboxFromBody (body: string, contentType: string) {
+  let inboxes
+  logger.debug(`inboxFromBody got response contentType=${contentType}`)
+  switch (contentType) {
+    case 'application/json':
+      try {
+        var object = JSON.parse(body)
+      } catch (e) {
+        throw new deliveryErrors.TargetParseFailed(e.message)
+      }
+      logger.debug("object", object)
+      inboxes = ensureArray(object.inbox).filter(Boolean)
+      break
+    case 'text/html':
+      let ld: Extendable<JSONLD>[] = await rdfaToJsonLd(body)
+      let targetSubject = ld.find((x) => x['@id'] === 'http://localhost/')
+      if ( ! targetSubject) {
+        logger.debug('no targetSubject so no ldb:inbox after checking text/html for ld. got ld', ld)
+        inboxes = []
+      } else {
+        inboxes = targetSubject['http://www.w3.org/ns/ldp#inbox'].map((i: JSONLD) => i['@id'])          
+      }
+      break;
+    case 'application/ld+json':
+      const obj = JSON.parse(body)
+      const compacted = await jsonld.compact(obj, {
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          {
+            'distbin:inbox': {
+              '@id': 'ldp:inbox',
+              '@container': '@set'
+            }
+          }
+        ]
+      })
+      const compactedInbox = (compacted['distbin:inbox'] || []).map((o: {id: string}) => typeof o === 'object' ? o.id : o)
+      inboxes = compactedInbox.length ? compactedInbox : ensureArray(obj.inbox)
+      break;
+    default:
+      throw new Error(`Don't know how to parse ${contentType} to determine inbox URL`)
+  }
+  if (!inboxes || !inboxes.length) {
+    logger.debug(`Could not determine ActivityPub inbox from ${contentType} response`)
+    return
+  }
+  if (inboxes.length > 1) {
+    logger.warn(`Using only first inbox, but there were ${inboxes.length}: ${inboxes}`)
+  }
+  const inbox: string = inboxes[0]
+  return inbox
 }

--- a/src/activitystreams/types.ts
+++ b/src/activitystreams/types.ts
@@ -1,41 +1,41 @@
-type ISO8601 = string
-type xsdAnyUri = string
+type ISO8601 = string;
+type xsdAnyUri = string;
 
-type OneOrMore<T> = T | T[]
+type OneOrMore<T> = T | T[];
 
 // ASLinked Data
-type LDIdentifier = xsdAnyUri
-export type LDValue<T> = (LDIdentifier | T)
-export type LDValues<T> = T | T[]
+type LDIdentifier = xsdAnyUri;
+export type LDValue<T> = (LDIdentifier | T);
+export type LDValues<T> = T | T[];
 export type LDObject<T> = {
     [P in keyof T]?: LDValues<T[P]>;
-}
+};
 type JSONLDContext = OneOrMore<string | {
-    '@vocab'?: string
-    '@language'?: string
-    [key:string]: string | {[key:string]: string}
-}>
+    "@vocab"?: string
+    "@language"?: string
+    [key: string]: string | {[key: string]: string},
+}>;
 export class JSONLD {
-  '@id': string
+  public "@id": string;
 }
 
 class ASBase {
-  '@context'?: JSONLDContext
+  public "@context"?: JSONLDContext;
 }
 
 // @TODO (bengo): enumerate known values?
-type LinkRelation = string
+type LinkRelation = string;
 
 export class ASLink {
-  type: ASObjectType<'Link'>
-  href: string
-  mediaType?: string
-  rel?: LinkRelation
+  public type: ASObjectType<"Link">;
+  public href: string;
+  public mediaType?: string;
+  public rel?: LinkRelation;
 }
 export const Link = ASLink
 
 export const isASLink = (obj: any): obj is ASLink => {
-  return obj.type === 'Link'
+  return obj.type === "Link";
 }
 
 // @TODO (bengo)
@@ -73,23 +73,23 @@ export class ASObject extends ASBase {
 }
 
 export const isASObject = (obj: any): obj is ASObject => {
-  return typeof obj === 'object'
+  return typeof obj === "object"
 }
 
 class ASImage extends ASObject {}
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#activity-types
 export const activitySubtypes = [
-  'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete',
-  'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like',
-  'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove',
-  'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View'
+  "Accept", "Add", "Announce", "Arrive", "Block", "Create", "Delete",
+  "Dislike", "Flag", "Follow", "Ignore", "Invite", "Join", "Leave", "Like",
+  "Listen", "Move", "Offer", "Question", "Reject", "Read", "Remove",
+  "TentativeReject", "TentativeAccept", "Travel", "Undo", "Update", "View"
 ]
 const ActivitySubtypes = strEnum(activitySubtypes)
 type ActivitySubtype = keyof typeof ActivitySubtypes
 
 export class Activity extends ASObject {
-  type: ASObjectType<'Activity' | ActivitySubtype>
+  type: ASObjectType<"Activity" | ActivitySubtype>
   actor?: ASValue
   object?: LDValue<ASObject>
   target?: ASValue
@@ -101,7 +101,7 @@ export class Activity extends ASObject {
 }
 
 export const isActivity = (activity: any): activity is Activity => {
-  if (typeof activity === 'object') {
+  if (typeof activity === "object") {
     return activitySubtypes.includes(activity.type)
   }
   return false
@@ -113,7 +113,7 @@ export class Collection<T> extends ASObject {
 }
 
 export class Note extends ASObject {
-  type: ASObjectType<'Note'>
+  type: ASObjectType<"Note">
 }
 
 export class Place extends ASObject {
@@ -122,7 +122,7 @@ export class Place extends ASObject {
   longitude?: number
   altitude?: number
   radius?: number
-  units?: 'cm' | 'feet' | 'inches' | 'km' | 'm' | 'miles' | xsdAnyUri
+  units?: "cm" | "feet" | "inches" | "km" | "m" | "miles" | xsdAnyUri
 }
 
 function strEnum<T extends string> (o: Array<T>): {[K in T]: K} {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,7 @@ export const createLogger = function getLogger (name: string) {
   const logger = new (winston.Logger)({
     transports: [
       new (winston.transports.Console)({
-        label: [defaultName, name].filter(Boolean).join('.')
+        label: [defaultName, name].filter(Boolean).join('.'),
       })
     ]
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
-import { IncomingMessage, ServerResponse } from 'http'
-import { Collection, Place, LDValue, LDValues, LDObject, JSONLD, ASLink, ASObject, Activity, isActivity } from './activitystreams/types'
+import { IncomingMessage, ServerResponse } from "http";
+import { Collection, Place, LDValue, LDValues, LDObject, JSONLD, ASLink, ASObject,
+         Activity, isActivity } from "./activitystreams/types";
 export { Collection, Place, LDValue, LDValues, LDObject, JSONLD, ASLink, ASObject, Activity, isActivity }
 
 type ISO8601 = string
 
-export type HttpRequestResponder = (req: IncomingMessage, res: ServerResponse) => void
+export type HttpRequestResponder = (req: IncomingMessage, res: ServerResponse) => void;
 
 export type Extendable<T> = T & {
     [key: string]: any
@@ -12,32 +13,32 @@ export type Extendable<T> = T & {
 
 // extra fields used by distbin
 export class DistbinActivity extends Activity {
-  'http://www.w3.org/ns/prov#wasDerivedFrom'?: LDValue<object>
+  public 'http://www.w3.org/ns/prov#wasDerivedFrom'?: LDValue<object>
   'distbin:activityPubDeliveryFailures'?: Error[]
 }
 export type ActivityMap = Map<string, Activity|DistbinActivity>
 
 type mediaType = string
 export class LinkPrefetchResult {
-  type: string
-  link: ASLink
+  public type: string
+  public link: ASLink
   constructor (props:any) {
     this.type = this.constructor.name
     Object.assign(this, props)
   }
 }
 export class LinkPrefetchSuccess extends LinkPrefetchResult {
-  type: 'LinkPrefetchSuccess'
-  published: ISO8601
-  supportedMediaTypes: mediaType[]
+  public type: 'LinkPrefetchSuccess'
+  public published: ISO8601
+  public supportedMediaTypes: mediaType[]
 }
 export class LinkPrefetchFailure extends LinkPrefetchResult {
-  type: 'LinkPrefetchFailure'
-  error: {
+  public type: 'LinkPrefetchFailure'
+  public error: {
        status?: number
        message: string
     }
 }
 export class HasLinkPrefetchResult {
-  'https://distbin.com/ns/linkPrefetch'?: LinkPrefetchResult
+  public 'https://distbin.com/ns/linkPrefetch'?: LinkPrefetchResult;
 }

--- a/test/activitypub.ts
+++ b/test/activitypub.ts
@@ -309,7 +309,7 @@ tests['can submit an Activity to the Outbox'] = async function () {
   req.write(JSON.stringify({
     '@context': 'https://www.w3.org/ns/activitypub',
     'type': 'Like',
-    'actor': 'https://dustycloud.org/chris/', // #TODO fix that there was a missing comma here in spec
+    'actor': 'https://bengo.is/proxy/dustycloud.org/chris/', // #TODO fix that there was a missing comma here in spec
     'name': "Chris liked 'Minimal ActivityPub update client'",
     'object': 'https://rhiaro.co.uk/2016/05/minimal-activitypub'
     // 'to': ['https://dustycloud.org/followers', 'https://rhiaro.co.uk/followers/'],

--- a/test/distbin.ts
+++ b/test/distbin.ts
@@ -409,7 +409,7 @@ tests['GET {activity.id}.json always sends json response, even if html if prefer
 }
 
 // post an activity to a distbin, and return its absolute url
-async function postActivity (distbinListener: HttpRequestResponder, activity: LDObject<ASObject>) {
+export async function postActivity (distbinListener: HttpRequestResponder, activity: LDObject<ASObject>) {
   const distbinUrl = await listen(http.createServer(distbinListener))
   const req = http.request(Object.assign(url.parse(distbinUrl), {
     headers: activitypub.clientHeaders({

--- a/test/distbin.ts
+++ b/test/distbin.ts
@@ -8,7 +8,7 @@ const http = require('http')
 const { isProbablyAbsoluteUrl } = require('./util')
 const { listen } = require('./util')
 const { readableToString } = require('../src/util')
-const { requestForListener } = require('./util')
+const { requestForListener, postActivity } = require('./util')
 const { linkToHref } = require('../src/util')
 const { ensureArray, sendRequest } = require('../src/util')
 import * as url from 'url'
@@ -406,23 +406,6 @@ tests['GET {activity.id}.json always sends json response, even if html if prefer
   assert.equal(activityResponse.statusCode, 200)
   const fetchedActivity = JSON.parse(await readableToString(activityResponse))
   assert.ok(fetchedActivity)
-}
-
-// post an activity to a distbin, and return its absolute url
-export async function postActivity (distbinListener: HttpRequestResponder, activity: LDObject<ASObject>) {
-  const distbinUrl = await listen(http.createServer(distbinListener))
-  const req = http.request(Object.assign(url.parse(distbinUrl), {
-    headers: activitypub.clientHeaders({
-      'content-type': ASJsonLdProfileContentType
-    }),
-    method: 'post',
-    path: '/activitypub/outbox'
-  }))
-  req.write(JSON.stringify(activity))
-  const res = await sendRequest(req)
-  assert.equal(res.statusCode, 201)
-  const activityUrl = url.resolve(distbinUrl, res.headers.location)
-  return activityUrl
 }
 
 if (require.main === module) {

--- a/test/federation.ts
+++ b/test/federation.ts
@@ -1,0 +1,50 @@
+// tests for distbin-specific stuff (arbitrary, non-protocol things)
+import { testCli } from ".";
+import distbin from "../";
+import { discoverOutbox } from "../src/activitypub";
+import { ASJsonLdProfileContentType } from "../src/activitystreams";
+import { readableToString } from "../src/util";
+import { linkToHref } from "../src/util";
+import { ensureArray, sendRequest } from "../src/util";
+import { inboxUrl } from "../src/activitypub";
+import { postActivity } from "./distbin";
+import { Activity, ASObject, DistbinActivity, Extendable, HttpRequestResponder,
+  isActivity, JSONLD, LDObject, LDValue, LDValues } from "./types";
+import { isProbablyAbsoluteUrl } from "./util";
+import { listen } from "./util";
+import { requestForListener } from "./util";
+
+import * as assert from "assert";
+import fetch from "node-fetch";
+import * as http from "http";
+import { get } from "lodash";
+import * as url from "url";
+
+const tests = module.exports;
+
+tests["On reply, notify inbox of parent's actor"] = async () => {
+  const distbinForParentActor = distbin({ deliverToLocalhost: true });
+  const parentActorUrl = await listen(http.createServer(distbinForParentActor))
+  const parent = {
+    actor: parentActorUrl,
+    content: "Anyone out there?"
+  }
+  const parentUrl = await listen(http.createServer((request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(parent, null, 2))
+  }))
+  const distbinA = distbin({ deliverToLocalhost: true });
+  // post a reply
+  const replyUrl = await postActivity(distbinA, {
+    cc: [parentUrl],
+    content: "Yes I am out there, parent",
+    inReplyTo: parentUrl,
+  });
+  const parentActorInboxResponse = await fetch(await inboxUrl(parentActorUrl))
+  const parentActorInbox = await parentActorInboxResponse.json()
+  assert.equal(parentActorInbox.items.length, 1)
+};
+
+if (require.main === module) {
+  testCli(tests);
+}

--- a/test/federation.ts
+++ b/test/federation.ts
@@ -7,7 +7,7 @@ import { readableToString } from "../src/util";
 import { linkToHref } from "../src/util";
 import { ensureArray, sendRequest } from "../src/util";
 import { inboxUrl } from "../src/activitypub";
-import { postActivity } from "./distbin";
+import { postActivity } from "./util";
 import { Activity, ASObject, DistbinActivity, Extendable, HttpRequestResponder,
   isActivity, JSONLD, LDObject, LDValue, LDValues } from "./types";
 import { isProbablyAbsoluteUrl } from "./util";

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,6 +4,7 @@ if (require.main === module) {
     require('./ldn'),
     require('./activitypub'),
     require('./distbin'),
+    require('./federation'),
     require('./filemap'),
     require('./distbin-html'),
     require('./http-utils')

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,8 @@
+
+import { createLogger } from '../src/logger'
+
+const logger = createLogger('test')
+
 // Run tests if this file is executed
 if (require.main === module) {
   Promise.all([
@@ -44,7 +49,7 @@ export async function run (tests: TestsMap) {
         // skip, doesn't match filter
           return
         }
-        // console.log('TEST: ', testName)
+        logger.debug('TEST: ', testName)
         let result
         try {
           result = runTest()

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,7 @@ const { sendRequest } = require('../src/util')
 import * as url from 'url'
 const activitypub = require('../src/activitypub')
 const assert = require('assert')
-import {Activity, HttpRequestResponder} from './types'
+import {Activity, HttpRequestResponder, LDObject} from './types'
 import {IncomingMessage, RequestOptions, Server, ServerResponse} from 'http'
 import { ASJsonLdProfileContentType } from '../src/activitystreams'
 
@@ -43,7 +43,7 @@ export const listen = function listen (server: Server, port = 0, hostname?: stri
 export const isProbablyAbsoluteUrl = require('../src/util').isProbablyAbsoluteUrl
 
 // post an activity to a distbin, and return its absolute url
-export const postActivity = async function postActivity (distbinListener: HttpRequestResponder, activity: Activity) {
+export const postActivity = async function postActivity (distbinListener: HttpRequestResponder, activity: LDObject<Activity>) {
   const distbinUrl = await listen(http.createServer(distbinListener))
   const req = http.request(Object.assign(url.parse(distbinUrl), {
     headers: activitypub.clientHeaders({


### PR DESCRIPTION
@clacke pointed out in #6 that distbin would not discover inboxes of actors of resources we try to notify.

i.e. let's say Alice posts comment A.
Bob replies to comment A with comment B (by posting comment A to distbin /outbox)

Previously (and still), if comment A itself has an as:inbox, distbin will notify that inbox. I call this a 'direct inbox' of the comment.
With this PR, if there is no 'direct inbox', we will look for an 'as:actor' of comment A. And if we find that, we will look for an 'as:inbox' on that actor. If we find this 'actor inbox', we will notify it.

One downside of distbin before this, and after, is that it will only find a single inbox and deliver to it. Followup work on this should support finding multiple inboxes that need to be notified, and notifying all of them. But that can come later.
