### PR TITLE
public application/octet-stream

### DIFF
--- a/src/distbin-html/public.ts
+++ b/src/distbin-html/public.ts
@@ -13,7 +13,9 @@ import { distbinBodyTemplate } from "./partials"
 
 export const createHandler = ({ apiUrl }: {apiUrl: string}) => {
   return async (req: IncomingMessage, res: ServerResponse) => {
-    res.writeHead(200)
+    res.writeHead(200, {
+      "content-type": "text/html",
+    })
     res.end(distbinBodyTemplate(`
       ${await createPublicBody(req, {
         apiUrl,


### PR DESCRIPTION
The public page is seen with the content type application/octet-stream when behind a NGINX Proxy