### PR TITLE
Adding Syntax Highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@types/accepts": "^1.3.5",
     "@types/dompurify": "0.0.31",
+    "@types/highlight.js": "^9.12.3",
     "@types/jsdom": "^11.0.5",
     "@types/lodash": "^4.14.85",
     "@types/marked": "^0.3.0",
@@ -18,6 +19,7 @@
     "@types/winston": "^2.3.7",
     "accepts": "^1.3.3",
     "dompurify": "^0.8.4",
+    "highlight.js": "^9.15.6",
     "jsdom": "^9.9.1",
     "jsonld": "^0.4.11",
     "jsonld-rdfa-parser": "^1.5.1",

--- a/src/distbin-html/an-activity.ts
+++ b/src/distbin-html/an-activity.ts
@@ -31,6 +31,7 @@ import { IncomingMessage, ServerResponse } from "http";
 import * as marked from "marked";
 import * as url from "url";
 import * as fs from 'fs';
+import { highlightAuto } from "highlight.js"
 
 import { createLogger } from "../logger";
 const logger = createLogger(__filename);
@@ -41,7 +42,7 @@ const failedToFetch = Symbol("is this a Link that distbin failed to fetch?");
 const highlightCss = fs.readFileSync(require.resolve('highlight.js/styles/github.css'), 'utf-8');
 marked.setOptions({
   highlight: function (code) {
-    return require('highlight.js').highlightAuto(code).value;
+    return highlightAuto(code).value;
   }
 });
 
@@ -598,7 +599,6 @@ export const createActivityCss = () => {
     code {
       background-color: rgba(0, 0, 0, 0.05);
       display: inline-block;
-      width: 100%;
     }
     ${highlightCss}
   `;

--- a/src/distbin-html/an-activity.ts
+++ b/src/distbin-html/an-activity.ts
@@ -26,12 +26,11 @@ import { distbinBodyTemplate } from "./partials";
 import { everyPageHead } from "./partials";
 import { sanitize } from "./sanitize";
 import { internalUrlRewriter } from "./url-rewriter";
-
+import * as fs from 'fs';
+import { highlightAuto } from "highlight.js"
 import { IncomingMessage, ServerResponse } from "http";
 import * as marked from "marked";
 import * as url from "url";
-import * as fs from 'fs';
-import { highlightAuto } from "highlight.js"
 
 import { createLogger } from "../logger";
 const logger = createLogger(__filename);
@@ -41,7 +40,7 @@ const failedToFetch = Symbol("is this a Link that distbin failed to fetch?");
 // Highlighting
 const highlightCss = fs.readFileSync(require.resolve('highlight.js/styles/github.css'), 'utf-8');
 marked.setOptions({
-  highlight: function (code) {
+  highlight (code) {
     return highlightAuto(code).value;
   }
 });

--- a/src/distbin-html/an-activity.ts
+++ b/src/distbin-html/an-activity.ts
@@ -26,6 +26,7 @@ import { distbinBodyTemplate } from "./partials";
 import { everyPageHead } from "./partials";
 import { sanitize } from "./sanitize";
 import { internalUrlRewriter } from "./url-rewriter";
+
 import * as fs from 'fs';
 import { highlightAuto } from "highlight.js"
 import { IncomingMessage, ServerResponse } from "http";

--- a/src/distbin-html/an-activity.ts
+++ b/src/distbin-html/an-activity.ts
@@ -30,11 +30,20 @@ import { internalUrlRewriter } from "./url-rewriter";
 import { IncomingMessage, ServerResponse } from "http";
 import * as marked from "marked";
 import * as url from "url";
+import * as fs from 'fs';
 
 import { createLogger } from "../logger";
 const logger = createLogger(__filename);
 
 const failedToFetch = Symbol("is this a Link that distbin failed to fetch?");
+
+// Highlighting
+const highlightCss = fs.readFileSync(require.resolve('highlight.js/styles/github.css'), 'utf-8');
+marked.setOptions({
+  highlight: function (code) {
+    return require('highlight.js').highlightAuto(code).value;
+  }
+});
 
 // create handler to to render a single activity to a useful page
 export const createHandler = ({
@@ -586,6 +595,12 @@ export const createActivityCss = () => {
     .action-show-raw pre {
       color: initial
     }
+    code {
+      background-color: rgba(0, 0, 0, 0.05);
+      display: inline-block;
+      width: 100%;
+    }
+    ${highlightCss}
   `;
 };
 


### PR DESCRIPTION
`const highlightCss = fs.readFileSync(require.resolve('highlight.js/styles/github.css'), 'utf-8');` allow to select a style from [highlight.js available styles](https://highlightjs.org/static/demo/)


I haven't been able to add line numbers. I don't if it's possible with marked package.
And if it's not possible, can we change the markdown package? Maybe you choose this one for good reasons

![Capture](https://user-images.githubusercontent.com/30271971/54800070-6b2a0c80-4c60-11e9-92c5-03152cfa6464.PNG)
